### PR TITLE
Add prefixes cmd arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The script will:
 ### --quiet
 (Optional) Disable debug output, only the resulting changelog will be printed.
 
-### --prefixes, -pf
+### --prefixes
 (Optional) PR prefixes. Default: Added,Changed,Deprecated,Removed,Fixed,Security.
 
 ## Example with Simple Podcasting

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ The script will:
 ### --quiet
 (Optional) Disable debug output, only the resulting changelog will be printed.
 
+### --prefixes, -pf
+(Optional) PR prefixes. Default: Added,Changed,Deprecated,Removed,Fixed,Security.
+
 ## Example with Simple Podcasting
 
 Let's create a changelog for the [release version 1.2.3](https://github.com/10up/simple-podcasting/milestone/11?closed=1)

--- a/cli.js
+++ b/cli.js
@@ -34,7 +34,6 @@ Options:
         },
         prefixes: {
           type: "string",
-          alias: "pf",
           default: "Added,Changed,Deprecated,Removed,Fixed,Security"
         },
         quiet: {

--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import meow from "meow";
 import GitHub from "./src/github.js";
-import { makeChangelog, makeGroups } from "./src/parse.js";
+import { makeChangelog, makeGroups, addPrefixes } from "./src/parse.js";
 
 async function run() {
   const cli = meow(
@@ -13,6 +13,7 @@ Options:
 --milestone, -m  Milestone title.
 --pat, -p        Personal access token.
 --style, -s      Changelog style: plain (default)
+--prefixes, -pf  PR prefixes. Default: Added,Changed,Deprecated,Removed,Fixed,Security
 --quiet          Disable debug output
 `,
     {
@@ -31,6 +32,11 @@ Options:
           alias: "s",
           default: "plain", // TODO Add "grouped" option
         },
+        prefixes: {
+          type: "string",
+          alias: "pf",
+          default: "Added,Changed,Deprecated,Removed,Fixed,Security"
+        },
         quiet: {
           type: "boolean",
           defalut: false,
@@ -38,6 +44,9 @@ Options:
       },
     }
   );
+
+  let prefixesPattern = '^(' + cli.flags.prefixes.replaceAll(",", "|") + ') - (.*?)$';
+  addPrefixes(prefixesPattern);
 
   if (!cli.flags.milestone) {
     cli.showHelp();

--- a/cli.js
+++ b/cli.js
@@ -13,7 +13,7 @@ Options:
 --milestone, -m  Milestone title.
 --pat, -p        Personal access token.
 --style, -s      Changelog style: plain (default)
---prefixes, -pf  PR prefixes. Default: Added,Changed,Deprecated,Removed,Fixed,Security
+--prefixes       PR prefixes. Default: Added,Changed,Deprecated,Removed,Fixed,Security
 --quiet          Disable debug output
 `,
     {

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,5 +1,8 @@
-const knownPrefixes =
-  /^(Added|Changed|Deprecated|Removed|Fixed|Security) - (.*?)$/;
+let knownPrefixes;
+
+export function addPrefixes(pattern) {
+  knownPrefixes = new RegExp(pattern);
+}
 
 export function makeChangelog(issue, participants) {
   // PR title by default.


### PR DESCRIPTION

### Description of the Change

Prefixes command line argument allows customize the output changelog, if the user does not need all the changes, or when adding new prefixes.


### Verification Process

I manually checked the functionality on the simple-podcasting repository.
This change will not result in regressions because by default application work with old prefixes.
I could not check the addition of new prefixes because I could not find any other prefixes in repository simple-podasting 

### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.


### Changelog Entry

Added - Prefixes command-line argument


### Credits

@countneuroman
