### PR TITLE
Bump node 16 minimum version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "email": "opensource@10up.com",
     "url": "https://10up.com"
   },
+  "engines": {
+    "node": ">=16.0"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
### Description of the Change

This PR sets minimum Node supported version

### Changelog Entry

Changed - Minimum supported Node version is set to 16

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @cadic
