### PR TITLE
Fallback PR title as changelog entry

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -20,7 +20,9 @@ export function makeChangelog(issue, participants) {
   }
 
   // PR title by default.
-  lines = [issue.title];
+  if (lines.length === 0) {
+	lines = [issue.title];	  
+  }
 
   return lines
     .filter((line) => line.length > 0) // non-empty

--- a/src/parse.js
+++ b/src/parse.js
@@ -5,17 +5,22 @@ export function addPrefixes(pattern) {
 }
 
 export function makeChangelog(issue, participants) {
-  // PR title by default.
-  let lines = [issue.title];
+  let lines = [];
 
   // Try to extract changelog entries from the description.
   const cleanBody = issue.body.replace(/<!--.*?-->/gs, "");
 
   const matches = /#\s*Changelog.*\r?\n([^#]+)/.exec(cleanBody);
   if (matches !== null) {
-    const changelog = matches[1];
-    lines = changelog.split(/\r?\n/);
+    const changelog = matches[1].trim().split(/\r?\n/);
+
+    lines = changelog
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length);
   }
+
+  // PR title by default.
+  lines = [issue.title];
 
   return lines
     .filter((line) => line.length > 0) // non-empty


### PR DESCRIPTION
### Description of the Change

In some PR descriptions the Changelog entry section is empty. This PR fixes this case, saving PR title as changelog entry.

Closes #13 

### Verification Process

In the 1.1.0 milestone of [10up/retro-winamp-block](https://github.com/10up/retro-winamp-block) some of PRs have empty Changelog entry section in the description. With this PR they are filled with PR title.

```
❯ changelog-generator --repo=git@github.com:10up/retro-winamp-block.git --milestone=1.1.0
Reading issues from Milestone "1.1.0"
Found PRs: 12
PR "Add PHPCS ruleset."
Found 3 participants
Extracted 1 changelog records
PR "[Trunk] Indicate support for WP 6.0."
Found 3 participants
Extracted 1 changelog records
PR "Indicate support for WP 6.0."
Found 3 participants
Extracted 1 changelog records
PR "Bump async from 2.6.3 to 2.6.4"
Found 2 participants
Extracted 1 changelog records
PR "Create dependency-review.yml"
Found 2 participants
Extracted 1 changelog records
PR "Bump moment from 2.29.1 to 2.29.2"
Found 2 participants
Extracted 1 changelog records
PR "Bump ansi-regex from 4.1.0 to 4.1.1"
Found 2 participants
Extracted 1 changelog records
PR "Bump minimist from 1.2.5 to 1.2.6"
Found 2 participants
Extracted 1 changelog records
PR "upkeep/40: PHP8 compat workflow"
Found 3 participants
Extracted 1 changelog records
PR "Bump nanoid from 3.1.30 to 3.3.1"
Found 2 participants
Extracted 1 changelog records
PR "Bump follow-redirects from 1.14.5 to 1.14.8"
Found 2 participants
Extracted 1 changelog records
PR "bump wp tested-up-to 5.9"
Found 2 participants
Extracted 1 changelog records


## Changelog:

- Added - Dependency security scanning. (props [@jeffpaul](https://github.com/jeffpaul), [@peterwilsoncc](https://github.com/peterwilsoncc)) via [#48](https://github.com/10up/retro-winamp-block/pull/48))
- Changed - Bump WordPress version "tested up to" 5.9. (props [@jeffpaul](https://github.com/jeffpaul), [@sudip-10up](https://github.com/sudip-10up)) via [#35](https://github.com/10up/retro-winamp-block/pull/35))
- Other - Add PHPCS ruleset. (props [@peterwilsoncc](https://github.com/peterwilsoncc), [@iamdharmesh](https://github.com/iamdharmesh), [@jeffpaul](https://github.com/jeffpaul)) via [#53](https://github.com/10up/retro-winamp-block/pull/53))
- Other - Indicate support for WP 6.0. (props [@peterwilsoncc](https://github.com/peterwilsoncc), [@dinhtungdu](https://github.com/dinhtungdu), [@jeffpaul](https://github.com/jeffpaul)) via [#51](https://github.com/10up/retro-winamp-block/pull/51))
- Other - [Trunk] Indicate support for WP 6.0. (props [@peterwilsoncc](https://github.com/peterwilsoncc), [@dinhtungdu](https://github.com/dinhtungdu), [@jeffpaul](https://github.com/jeffpaul)) via [#52](https://github.com/10up/retro-winamp-block/pull/52))
- Other - upkeep: Added PHP8 compatibility workflow (props [@Sidsector9](https://github.com/Sidsector9), [@faisal-alvi](https://github.com/faisal-alvi), [@jeffpaul](https://github.com/jeffpaul)) via [#39](https://github.com/10up/retro-winamp-block/pull/39))
- Security - Bump ansi-regex from 4.1.0 to 4.1.1 (props [@dependabot[bot]](https://github.com/apps/dependabot), [@jeffpaul](https://github.com/jeffpaul)) via [#42](https://github.com/10up/retro-winamp-block/pull/42))
- Security - Bump async from 2.6.3 to 2.6.4 (props [@dependabot[bot]](https://github.com/apps/dependabot), [@jeffpaul](https://github.com/jeffpaul)) via [#49](https://github.com/10up/retro-winamp-block/pull/49))
- Security - Bump follow-redirects from 1.14.5 to 1.14.8 (props [@dependabot[bot]](https://github.com/apps/dependabot), [@jeffpaul](https://github.com/jeffpaul)) via [#36](https://github.com/10up/retro-winamp-block/pull/36))
- Security - Bump minimist from 1.2.5 to 1.2.6 (props [@dependabot[bot]](https://github.com/apps/dependabot), [@jeffpaul](https://github.com/jeffpaul)) via [#41](https://github.com/10up/retro-winamp-block/pull/41))
- Security - Bump moment from 2.29.1 to 2.29.2 (props [@dependabot[bot]](https://github.com/apps/dependabot), [@jeffpaul](https://github.com/jeffpaul)) via [#43](https://github.com/10up/retro-winamp-block/pull/43))
- Security - Bump nanoid from 3.1.30 to 3.3.1 (props [@dependabot[bot]](https://github.com/apps/dependabot), [@jeffpaul](https://github.com/jeffpaul)) via [#37](https://github.com/10up/retro-winamp-block/pull/37))

```

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Fixed - No entries found if "Changelog entry" description is empty

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @cadic @Sidsector9 
