### PR TITLE
WordPress output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The script will:
 (Optional) Custom GitHub repository address. Default is `empty`, use repository from the current folder.
 
 ### --style, -s
-(Optional) Output style
+(Optional) Output style, multiple comma-separated values allowed
 - `grouped` Group changelog entries (Added, Fixed, etc.)
 - `wordpress` WordPress readme.txt format
 - `plain` (default) plain list of changelog entries

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The script will:
 ### --style, -s
 (Optional) Output style
 - `grouped` Group changelog entries (Added, Fixed, etc.)
+- `wordpress` WordPress readme.txt format
 - `plain` (default) plain list of changelog entries
 
 ### --quiet


### PR DESCRIPTION
### Description of the Change

Added new option `--style=wordpress` for WordPress-like readme.txt output
Style option now accepts multiple comma-separated values

Closes #1 

### Verification Process

```
❯ changelog-generator --repo=git@github.com:10up/simple-podcasting.git --milestone=1.2.2 --style=wordpress

== Changelog ==

= 1.2.2 - 2022-06-16 =
* **Added** Auto-create pot file in languages folder during the build process (props [@cadic](https://github.com/cadic), [@dkotter](https://github.com/dkotter)) via [#131](https://github.com/10up/simple-podcasting/pull/131))
* **Added** Filter 'simple_podcasting_feed_item' to modify RSS feed item data before output (props [@cadic](https://github.com/cadic), [@iamdharmesh](https://github.com/iamdharmesh), [@jeffpaul](https://github.com/jeffpaul)) via [#144](https://github.com/10up/simple-podcasting/pull/144))
* **Added** Unit tests (props [@cadic](https://github.com/cadic), [@jeffpaul](https://github.com/jeffpaul), [@dkotter](https://github.com/dkotter)) via [#142](https://github.com/10up/simple-podcasting/pull/142))
* **Changed** Bump WordPress "tested up to" version 5.9 (props @sudip-10up @cadic). (props [@sudip-10up](https://github.com/sudip-10up), [@cadic](https://github.com/cadic), [@jeffpaul](https://github.com/jeffpaul), [@peterwilsoncc](https://github.com/peterwilsoncc)) via [#140](https://github.com/10up/simple-podcasting/pull/140))
* **Fixed** Bug fix for is_feed being called too early (props [@tomjn](https://github.com/tomjn), [@jeffpaul](https://github.com/jeffpaul), [@cadic](https://github.com/cadic)) via [#135](https://github.com/10up/simple-podcasting/pull/135))
* **Fixed** Cypress tests with WordPress 5.9 (props [@cadic](https://github.com/cadic), [@felipeelia](https://github.com/felipeelia), [@dinhtungdu](https://github.com/dinhtungdu)) via [#146](https://github.com/10up/simple-podcasting/pull/146))
* **Fixed** Missing and incorrect text-domain (props [@cadic](https://github.com/cadic), [@dkotter](https://github.com/dkotter)) via [#131](https://github.com/10up/simple-podcasting/pull/131))
* **Other** Add - GitHub action job to run PHPCS (props [@cadic](https://github.com/cadic), [@dkotter](https://github.com/dkotter)) via [#136](https://github.com/10up/simple-podcasting/pull/136))
* **Other** Fix feed link output issue (props [@cadic](https://github.com/cadic), [@mehidi258](https://github.com/mehidi258), [@jeffpaul](https://github.com/jeffpaul)) via [#139](https://github.com/10up/simple-podcasting/pull/139))
* **Other** None (props [@cadic](https://github.com/cadic), [@iamdharmesh](https://github.com/iamdharmesh)) via [#132](https://github.com/10up/simple-podcasting/pull/132))
* **Other** Release/1.2.2 (props [@cadic](https://github.com/cadic), [@jeffpaul](https://github.com/jeffpaul)) via [#151](https://github.com/10up/simple-podcasting/pull/151))
* **Security** Bump nanoid from 3.1.25 to 3.2.0 (props [@dependabot[bot]](https://github.com/apps/dependabot), [@jeffpaul](https://github.com/jeffpaul), [@cadic](https://github.com/cadic)) via [#143](https://github.com/10up/simple-podcasting/pull/143))
* **Security** Bump tmpl from 1.0.4 to 1.0.5 (props [@dependabot[bot]](https://github.com/apps/dependabot), [@jeffpaul](https://github.com/jeffpaul), [@cadic](https://github.com/cadic)) via [#128](https://github.com/10up/simple-podcasting/pull/128))


```
<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Added - WordPress-like readme.txt output style

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @cadic
