### PR TITLE
Improved GitHub username regexp

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -5,23 +5,16 @@ export function addPrefixes(pattern) {
 }
 
 export function makeChangelog(issue, participants) {
-  let lines = [];
+  // PR title by default.
+  let lines = [issue.title];
 
   // Try to extract changelog entries from the description.
   const cleanBody = issue.body.replace(/<!--.*?-->/gs, "");
 
   const matches = /#\s*Changelog.*\r?\n([^#]+)/.exec(cleanBody);
   if (matches !== null) {
-    const changelog = matches[1].trim().split(/\r?\n/);
-
-    lines = changelog
-      .map((entry) => entry.trim())
-      .filter((entry) => entry.length);
-  }
-
-  // PR title by default.
-  if (lines.length === 0) {
-	lines = [issue.title];	  
+    const changelog = matches[1];
+    lines = changelog.split(/\r?\n/);
   }
 
   return lines
@@ -57,7 +50,7 @@ export function makeCredits(issue) {
   let credits = [];
   const matches = /#\s*Credits.*\r?\n([^#]+)/.exec(cleanBody);
   if (matches !== null) {
-    credits = matches[1].match(/@(^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38})/g);
+    credits = matches[1].match(/@([\w\-^_]+)/g);
     if (credits !== null) {
       return credits.map((item) => {
         item = item.trim().replace("@", "");

--- a/src/parse.js
+++ b/src/parse.js
@@ -57,7 +57,7 @@ export function makeCredits(issue) {
   let credits = [];
   const matches = /#\s*Credits.*\r?\n([^#]+)/.exec(cleanBody);
   if (matches !== null) {
-    credits = matches[1].match(/@([^\s,]+)/g);
+    credits = matches[1].match(/@(^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38})/g);
     if (credits !== null) {
       return credits.map((item) => {
         item = item.trim().replace("@", "");


### PR DESCRIPTION
### Description of the Change

Before the PR, a simple regexp was used to extract participant names from the description (was looking for @ followed by non-space characters). It caused

<!-- Enter any applicable Issues here. Example: -->
Closes #17 

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Fixed - Duplicate username with punctuation marks
<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->
