### PR TITLE
Remove ordered and unordered list bullets from changelog entries

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -5,6 +5,13 @@ export function addPrefixes(pattern) {
 }
 
 export function makeChangelog(issue, participants) {
+  return makeEntries(issue)
+    .map((line) => addProps(line, participants))
+    .map((line) => addVia(line, issue))
+    .map((line) => makePrefix(line, participants)); // Add prefix to lines which don't have it;
+}
+
+export function makeEntries(issue) {
   // PR title by default.
   let lines = [issue.title];
 
@@ -18,11 +25,8 @@ export function makeChangelog(issue, participants) {
   }
 
   return lines
-    .filter((line) => line.length > 0) // non-empty
-    .map((line) => line.replace(/^>\s/, "")) // remove "RE" prefix
-    .map((line) => addProps(line, participants))
-    .map((line) => addVia(line, issue))
-    .map((line) => makePrefix(line, participants)); // Add prefix to lines which don't have it;
+    .filter((line) => line.length > 0)
+    .map((line) => line.replace(/^>\s/, "")); // remove "RE" prefix
 }
 
 export function makeGroups(entries) {

--- a/src/parse.js
+++ b/src/parse.js
@@ -26,7 +26,9 @@ export function makeEntries(issue) {
 
   return lines
     .filter((line) => line.length > 0)
-    .map((line) => line.replace(/^>\s/, "")); // remove "RE" prefix
+    .map((line) => line.replace(/^>\s/, "")) // remove "RE" prefix
+    .map((line) => line.replace(/^-\s/, "")) // unordered list
+	.map((line) => line.replace(/^[\d]+\.\s/, "")) // ordered list
 }
 
 export function makeGroups(entries) {

--- a/test/make-entries.test.js
+++ b/test/make-entries.test.js
@@ -1,0 +1,36 @@
+import { makeEntries } from "../src/parse.js";
+import { expect } from "chai";
+
+describe("Entries tests", () => {
+  it("Make single entry", () => {
+    const issue = {
+      body: "### Changelog\n\nAdded - some feature",
+    };
+    const result = makeEntries(issue);
+    expect(result).to.deep.equal(["Added - some feature"]);
+  });
+
+  it("Make multiple entries", () => {
+    const issue = {
+      body: "### Changelog\n\nAdded - some feature\nAdded - another feature",
+    };
+    const result = makeEntries(issue);
+    expect(result).to.deep.equal([
+      "Added - some feature",
+      "Added - another feature",
+    ]);
+  });
+
+  it("Clean up bullets", () => {
+    const issue = {
+      body: "### Changelog\n\n> Added - some feature\n- Added - another issue\n1. Added - first\n2. Added - second",
+    };
+    const result = makeEntries(issue);
+    expect(result).to.deep.equal([
+      "Added - some feature",
+      "Added - another issue",
+      "Added - first",
+      "Added - second",
+    ]);
+  });
+});


### PR DESCRIPTION
### Description of the Change

Adds new separate function to extract changelof entries from PR description

Clean ordered and unordered list bullets from entry text

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Fixed - Remove ordered and unordered list bullets from changelog entries

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

